### PR TITLE
fix: improve hook validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,25 @@ const pf = new PluginFactory("plugin-name");
 
   pf
     .addBeforeHook(beforeHook)
-    // Similar api for the following methods
-    .addBeforeAllHook(...)
+    .addBeforeHook("@foo", beforeHook)
+    .addBeforeHook({ tags: "@foo" }, beforeHook)
+    // Similar api for the following method
     .addAfterHook(...)
-    .addAfterAllHook(...);
+```
+
+Interface is a bit different for `addBeforeAllHook` and `addAfterAllHook`:
+
+```js
+  const beforeAllHook = () => {
+    console.log("Before all hook");
+  }
+
+  pf
+    .addBeforeAllHook(beforeAllHook)
+    // Passing a string as first argument is not valid
+    .addBeforeAllHook({ tags: "@foo" }, beforeAllHook)
+    // Similar api for the following method
+    .addAfterAllHook(...)
 ```
 
 ### You can add state too:

--- a/index.d.ts
+++ b/index.d.ts
@@ -52,7 +52,7 @@ export default class PluginFactory<Config = {}> {
   /**
    * add a BeforeAll hook
    */
-   addBeforeAllHook: PluginFactory.AddHookFunc<Config>;
+   addBeforeAllHook: PluginFactory.RestrictedAddHookFunc<Config>;
 
   /**
    * add a After hook
@@ -62,7 +62,7 @@ export default class PluginFactory<Config = {}> {
   /**
    * add a A hook
    */
-   addAfterAllHook: PluginFactory.AddHookFunc<Config>;
+   addAfterAllHook: PluginFactory.RestrictedAddHookFunc<Config>;
 
   /**
    * Return the config
@@ -101,6 +101,10 @@ declare namespace PluginFactory {
   export type AddHookFunc<C> = 
     | ((options: { tags: string }, fn: HandlerFunc) => PluginFactory<C>)
     | ((tags: string, fn: HandlerFunc) => PluginFactory<C>)
+    | ((fn: HandlerFunc) => PluginFactory<C>);
+
+  export type RestrictedAddHookFunc<C> = 
+    | ((options: { tags: string }, fn: HandlerFunc) => PluginFactory<C>)
     | ((fn: HandlerFunc) => PluginFactory<C>);
 
   export interface Step {

--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ module.exports = class PluginFactory {
   }
 
   addBeforeAllHook(...args) {
-    this._checkHookArguments(args, "addBeforeAllHook");
+    this._checkRestrictedHookArguments(args, "addBeforeAllHook");
 
     this._beforeAllHooks.push(args);
 
@@ -83,7 +83,7 @@ module.exports = class PluginFactory {
   }
 
   addAfterAllHook(...args) {
-    this._checkHookArguments(args, "addAfterAllHook");
+    this._checkRestrictedHookArguments(args, "addAfterAllHook");
 
     this._afterAllHooks.push(args);
 
@@ -162,7 +162,23 @@ module.exports = class PluginFactory {
       !firstArg.tags
     ) {
       throw new TypeError(
-        `${functionContextName} first parameter should be a function a string or an object but got ${typeof firstArg}`
+        `${functionContextName} first parameter should be a function a string or an object with a tags property but got ${typeof firstArg}`
+      );
+    } else if (
+      typeof firstArg !== "function" &&
+      typeof secondArg !== "function"
+    ) {
+      throw new TypeError(
+        `${functionContextName} second parameter should be a function but got ${typeof secondArg}`
+      );
+    }
+  }
+
+  _checkRestrictedHookArguments(args, functionContextName = "hook") {
+    const [firstArg, secondArg] = args;
+    if (typeof firstArg !== "function" && !firstArg.tags) {
+      throw new TypeError(
+        `${functionContextName} first parameter should be a function or an object with a tags property but got ${typeof firstArg}`
       );
     } else if (
       typeof firstArg !== "function" &&

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -167,16 +167,19 @@ describe("PluginFactory", () => {
       expect(pf._beforeAllHooks).toEqual([[validOptions, validHook]]);
     });
 
-    it("addBeforeAllHook should callable with a string and a hook function", () => {
+    it("addBeforeAllHook should not be callable with a string and a hook function", () => {
       const pf = new PluginFactory("test");
-      const validTag = "@foo";
+      const notValidTag = "@foo";
       const validHook = () => {
         console.log("Hooked !");
       };
+      const expectedError = new TypeError(
+        `addBeforeAllHook first parameter should be a function or an object with a tags property but got ${typeof notValidTag}`
+      );
 
-      pf.addBeforeAllHook(validTag, validHook);
-
-      expect(pf._beforeAllHooks).toEqual([[validTag, validHook]]);
+      expect(() => pf.addBeforeAllHook(notValidTag, validHook)).toThrow(
+        expectedError
+      );
     });
 
     it("should expose an addAfterAllHook method", () => {
@@ -202,16 +205,19 @@ describe("PluginFactory", () => {
       expect(pf._afterAllHooks).toEqual([[validOptions, validHook]]);
     });
 
-    it("addAfterAllHook should callable with a string and a hook function", () => {
+    it("addAfterAllHook should not be callable with a string and a hook function", () => {
       const pf = new PluginFactory("test");
-      const validTag = "@foo";
+      const notValidTag = "@foo";
       const validHook = () => {
         console.log("Hooked !");
       };
+      const expectedError = new TypeError(
+        `addAfterAllHook first parameter should be a function or an object with a tags property but got ${typeof notValidTag}`
+      );
 
-      pf.addAfterAllHook(validTag, validHook);
-
-      expect(pf._afterAllHooks).toEqual([[validTag, validHook]]);
+      expect(() => pf.addAfterAllHook(notValidTag, validHook)).toThrow(
+        expectedError
+      );
     });
   });
 


### PR DESCRIPTION
## Change description

While implementing the e2e tests in the project I saw that `cucumber.Before` and `cucumber.BeforeAll` got different interfaces (same for After & AfterAll).

So I update tests cases and add a new validator for `BeforeAll` and `AfterAll` hook different from `Before` and `After`


## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Fix issue #8 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows project security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to issue tracker where applicable

